### PR TITLE
Issue 25: Add `Has_Data` attribute and change naming of attribute statements

### DIFF
--- a/language/ast.py
+++ b/language/ast.py
@@ -206,9 +206,9 @@ class Assignment(Statement):
     expression = Field(type=Expr)
 
 
-class ListAttr(RFLXNode):
+class AttrStmt(RFLXNode):
     """
-    List attribute kind
+    Attribute statement kind
     """
 
     enum_node = True
@@ -220,19 +220,19 @@ class ListAttr(RFLXNode):
     ]
 
 
-class ListAttribute(Statement):
+class AttributeStatement(Statement):
     """
-    List attribute statement
+    Attribute statement
     """
 
     identifier = Field(type=UnqualifiedID)
-    attr = Field(type=ListAttr)
+    attr = Field(type=AttrStmt)
     expression = Field(type=Expr)
 
 
 class Reset(Statement):
     """
-    List reset statement
+    Reset statement
     """
 
     identifier = Field(type=UnqualifiedID)

--- a/language/ast.py
+++ b/language/ast.py
@@ -519,6 +519,7 @@ class Attr(RFLXNode):
         "Size",
         "Last",
         "Valid_Checksum",
+        "Has_Data",
         "Head",
         "Opaque",
         "Present",

--- a/language/lexer.py
+++ b/language/lexer.py
@@ -65,6 +65,7 @@ class Token(LexerToken):
     Last = WithText()
     Checksum = WithText()
     ValidChecksum = WithText()
+    HasData = WithText()
     Head = WithText()
     Opaque = WithText()
     Present = WithText()
@@ -139,6 +140,7 @@ rflx_lexer.add_rules(
             ("Last", Token.Last),
             ("Size", Token.Size),
             ("Valid_Checksum", Token.ValidChecksum),
+            ("Has_Data", Token.HasData),
             ("Head", Token.Head),
             ("Opaque", Token.Opaque),
             ("Present", Token.Present),
@@ -208,6 +210,7 @@ rflx_lexer.add_rules(
     (Literal("Reset"), Token.Reset),
     (Literal("Checksum"), Token.Checksum),
     (Literal("Valid_Checksum"), Token.ValidChecksum),
+    (Literal("Has_Data"), Token.HasData),
     (Literal("Head"), Token.Head),
     (Literal("Opaque"), Token.Opaque),
     (Literal("Present"), Token.Present),

--- a/language/parser.py
+++ b/language/parser.py
@@ -186,6 +186,7 @@ grammar.add_rules(
                 ast.Attr.alt_size(lexer.Size),
                 ast.Attr.alt_last(lexer.Last),
                 ast.Attr.alt_valid_checksum(lexer.ValidChecksum),
+                ast.Attr.alt_has_data(lexer.HasData),
                 ast.Attr.alt_head(lexer.Head),
                 ast.Attr.alt_opaque(lexer.Opaque),
                 ast.Attr.alt_present(lexer.Present),

--- a/language/parser.py
+++ b/language/parser.py
@@ -431,15 +431,15 @@ grammar.add_rules(
     assignment_statement=ast.Assignment(
         grammar.unqualified_identifier, ":=", grammar.extended_expression
     ),
-    list_attribute=ast.ListAttribute(
+    list_attribute=ast.AttributeStatement(
         grammar.unqualified_identifier,
         "'",
         Or(
             # pylint: disable=no-member
-            ast.ListAttr.alt_append("Append"),
-            ast.ListAttr.alt_extend("Extend"),
-            ast.ListAttr.alt_read("Read"),
-            ast.ListAttr.alt_write("Write"),
+            ast.AttrStmt.alt_append("Append"),
+            ast.AttrStmt.alt_extend("Extend"),
+            ast.AttrStmt.alt_read("Read"),
+            ast.AttrStmt.alt_write("Write"),
         ),
         "(",
         grammar.extended_expression,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from typing import Any
 import setuptools.command.build_py as orig
 from setuptools import setup
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 base_dir = os.path.dirname(os.path.abspath(__file__))
 LANGKIT = f"langkit @ file://localhost/{base_dir}/contrib/langkit#egg=langkit"
 

--- a/tests/data/session/tls_record_session.rflx
+++ b/tests/data/session/tls_record_session.rflx
@@ -52,7 +52,7 @@ package TLS_Record_Session is
       state IDLE_MESSAGE is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Application_Control_Channel);
+         Available := Application_Control_Channel'Has_Data;
       transition
          then CONTROL
             if Available = True
@@ -62,7 +62,7 @@ package TLS_Record_Session is
       state IDLE_HANDSHAKE_CONTROL is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Handshake_Control_Channel);
+         Available := Handshake_Control_Channel'Has_Data;
       transition
          then HANDSHAKE_CONTROL
             if Available = True
@@ -72,7 +72,7 @@ package TLS_Record_Session is
       state IDLE_HANDSHAKE is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Handshake_Data_Channel);
+         Available := Handshake_Data_Channel'Has_Data;
       transition
          then HANDSHAKE
             if Available = True
@@ -82,7 +82,7 @@ package TLS_Record_Session is
       state IDLE_NETWORK is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Network_Channel);
+         Available := Network_Channel'Has_Data;
       transition
          then NETWORK_IN
             if Available = True
@@ -93,7 +93,7 @@ package TLS_Record_Session is
       state IDLE_APPLICATION is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Data_Channel);
+         Available := Data_Channel'Has_Data;
       transition
          then NETWORK_OUT_APPLICATION
             if Available = True
@@ -103,7 +103,7 @@ package TLS_Record_Session is
       state IDLE_HEARTBEAT is
          Available : Boolean := False;
       begin
-         Available := Data_Available (Heartbeat_Data_Channel);
+         Available := Heartbeat_Data_Channel'Has_Data;
       transition
          then HEARTBEAT
             if Available = True

--- a/tests/grammar_test.py
+++ b/tests/grammar_test.py
@@ -225,6 +225,21 @@ def test_variable(string: str, expected: Dict[str, str]) -> None:
             },
         ),
         (
+            "X'Has_Data",
+            {
+                "_kind": "Attribute",
+                "expression": {
+                    "_kind": "Variable",
+                    "identifier": {
+                        "_kind": "ID",
+                        "name": {"_kind": "UnqualifiedID", "_value": "X"},
+                        "package": None,
+                    },
+                },
+                "kind": {"_kind": "AttrHasData", "_value": "Has_Data"},
+            },
+        ),
+        (
             "X'Head",
             {
                 "_kind": "Attribute",

--- a/tests/grammar_test.py
+++ b/tests/grammar_test.py
@@ -2839,8 +2839,8 @@ def test_assignment_statement(string: str, expected: Dict[str, str]) -> None:
         (
             "A'Append (B)",
             {
-                "_kind": "ListAttribute",
-                "attr": {"_kind": "ListAttrAppend", "_value": "Append"},
+                "_kind": "AttributeStatement",
+                "attr": {"_kind": "AttrStmtAppend", "_value": "Append"},
                 "expression": {
                     "_kind": "Variable",
                     "identifier": {
@@ -2855,8 +2855,8 @@ def test_assignment_statement(string: str, expected: Dict[str, str]) -> None:
         (
             "A'Extend (B)",
             {
-                "_kind": "ListAttribute",
-                "attr": {"_kind": "ListAttrExtend", "_value": "Extend"},
+                "_kind": "AttributeStatement",
+                "attr": {"_kind": "AttrStmtExtend", "_value": "Extend"},
                 "expression": {
                     "_kind": "Variable",
                     "identifier": {
@@ -2871,8 +2871,8 @@ def test_assignment_statement(string: str, expected: Dict[str, str]) -> None:
         (
             "A'Read (B)",
             {
-                "_kind": "ListAttribute",
-                "attr": {"_kind": "ListAttrRead", "_value": "Read"},
+                "_kind": "AttributeStatement",
+                "attr": {"_kind": "AttrStmtRead", "_value": "Read"},
                 "expression": {
                     "_kind": "Variable",
                     "identifier": {
@@ -2887,8 +2887,8 @@ def test_assignment_statement(string: str, expected: Dict[str, str]) -> None:
         (
             "A'Write (B)",
             {
-                "_kind": "ListAttribute",
-                "attr": {"_kind": "ListAttrWrite", "_value": "Write"},
+                "_kind": "AttributeStatement",
+                "attr": {"_kind": "AttrStmtWrite", "_value": "Write"},
                 "expression": {
                     "_kind": "Variable",
                     "identifier": {


### PR DESCRIPTION
This will also change the naming of "list attributes" to "attribute statements". The list attributes also contained `Read` and `Write` which are actually channel attributes.

Closes #25